### PR TITLE
feat: add multi-image generation support and fix counter

### DIFF
--- a/src/components/canvas/StreamingImage.tsx
+++ b/src/components/canvas/StreamingImage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import type { ActiveGeneration } from "@/types/canvas";
+import { extractJobAssets } from "@/hooks/useImageGeneration";
 
 interface StreamingImageProps {
   imageId: string;
@@ -9,157 +10,213 @@ interface StreamingImageProps {
   onStatus?: (imageId: string, status: string, job?: any) => void;
 }
 
-export const StreamingImage: React.FC<StreamingImageProps> = ({
-  imageId,
-  generation,
-  onComplete,
-  onError,
-  onStatus,
-}) => {
-  const pollingRef = useRef<number | null>(null);
+export const StreamingImage: React.FC<StreamingImageProps> = React.memo(
+  ({ imageId, generation, onComplete, onError, onStatus }) => {
+    const pollingRef = useRef<number | null>(null);
 
-  useEffect(() => {
-    if (!generation.runId) {
-      return;
-    }
-
-    let isCancelled = false;
-
-    const clearPolling = () => {
-      if (pollingRef.current !== null) {
-        window.clearTimeout(pollingRef.current);
-        pollingRef.current = null;
-      }
-    };
-
-    const scheduleNextPoll = (delay: number, attempt: number) => {
-      clearPolling();
-      pollingRef.current = window.setTimeout(() => pollStatus(attempt), delay);
-    };
-
-    const extractAssetUrl = (
-      job: any,
-    ): { url: string; width?: number; height?: number } | null => {
-      const result =
-        job?.result || job?.output?.result || job?.output?.data?.result;
-      if (!result) {
-        return null;
-      }
-
-      if (result.r2OriginalUrl || result.r2_thumbnail_url) {
-        return {
-          url: (result.r2OriginalUrl || result.r2_thumbnail_url) as string,
-          width: result.metadata?.width,
-          height: result.metadata?.height,
-        };
-      }
-
-      if (result.url) {
-        return {
-          url: result.url,
-          width: result.metadata?.width,
-          height: result.metadata?.height,
-        };
-      }
-
-      if (Array.isArray(result.images) && result.images.length > 0) {
-        const image =
-          result.images.find((img: any) => img.r2OriginalUrl || img.url) ||
-          result.images[0];
-        return {
-          url: (image.r2OriginalUrl ||
-            image.r2_thumbnail_url ||
-            image.url) as string,
-          width: image.metadata?.width ?? result.metadata?.width,
-          height: image.metadata?.height ?? result.metadata?.height,
-        };
-      }
-
-      return null;
-    };
-
-    const pollStatus = async (attempt = 0) => {
-      if (isCancelled) {
+    useEffect(() => {
+      if (!generation.runId) {
         return;
       }
 
-      try {
-        const endpoint = `/api/jobs/status/${generation.runId}`;
-        const response = await fetch(endpoint, {
-          credentials: "include",
-        });
+      // Only coordinator processes the job, others wait
+      if (generation.isCoordinator === false) {
+        console.log(
+          `StreamingImage ${imageId}: Not coordinator, waiting for coordinator to complete`,
+        );
+        return;
+      }
 
-        if (response.status === 404) {
-          if (attempt < 3) {
+      console.log(
+        `StreamingImage ${imageId}: Acting as coordinator for placeholders:`,
+        generation.placeholderIds,
+      );
+
+      let isCancelled = false;
+
+      const clearPolling = () => {
+        if (pollingRef.current !== null) {
+          window.clearTimeout(pollingRef.current);
+          pollingRef.current = null;
+        }
+      };
+
+      const scheduleNextPoll = (delay: number, attempt: number) => {
+        clearPolling();
+        // Exponential backoff with jitter to reduce server load
+        const exponentialDelay = Math.min(
+          delay * Math.pow(1.5, attempt),
+          10000,
+        );
+        const jitter = Math.random() * 1000;
+        const finalDelay = exponentialDelay + jitter;
+
+        pollingRef.current = window.setTimeout(
+          () => pollStatus(attempt),
+          finalDelay,
+        );
+      };
+
+      const extractAssetUrl = (
+        job: any,
+      ): { url: string; width?: number; height?: number } | null => {
+        const result =
+          job?.result || job?.output?.result || job?.output?.data?.result;
+        if (!result) {
+          return null;
+        }
+
+        if (result.r2OriginalUrl || result.r2_thumbnail_url) {
+          return {
+            url: (result.r2OriginalUrl || result.r2_thumbnail_url) as string,
+            width: result.metadata?.width,
+            height: result.metadata?.height,
+          };
+        }
+
+        if (result.url) {
+          return {
+            url: result.url,
+            width: result.metadata?.width,
+            height: result.metadata?.height,
+          };
+        }
+
+        if (Array.isArray(result.images) && result.images.length > 0) {
+          const image =
+            result.images.find((img: any) => img.r2OriginalUrl || img.url) ||
+            result.images[0];
+          return {
+            url: (image.r2OriginalUrl ||
+              image.r2_thumbnail_url ||
+              image.url) as string,
+            width: image.metadata?.width ?? result.metadata?.width,
+            height: image.metadata?.height ?? result.metadata?.height,
+          };
+        }
+
+        return null;
+      };
+
+      const pollStatus = async (attempt = 0) => {
+        if (isCancelled) {
+          return;
+        }
+
+        try {
+          const endpoint = `/api/jobs/status/${generation.runId}`;
+          const response = await fetch(endpoint, {
+            credentials: "include",
+          });
+
+          if (response.status === 404) {
+            if (attempt < 3) {
+              scheduleNextPoll(1500 * (attempt + 1), attempt + 1);
+              return;
+            }
+            onError(imageId, "Generation not found.");
+            return;
+          }
+
+          if (!response.ok) {
+            const errorBody = await response
+              .text()
+              .catch(() => "Failed to fetch generation status.");
+            throw new Error(errorBody || "Failed to fetch generation status.");
+          }
+
+          const payload = await response.json();
+          const job = payload.job ?? payload;
+
+          const rawStatus = (
+            job?.output?.status ||
+            job?.status ||
+            "unknown"
+          ).toString();
+          const normalizedStatus = rawStatus.toLowerCase();
+
+          onStatus?.(imageId, rawStatus, job);
+
+          if (normalizedStatus === "completed") {
+            // Coordinator processes multiple assets and distributes them
+            if (
+              generation.isCoordinator &&
+              generation.placeholderIds &&
+              generation.placeholderIds.length > 1
+            ) {
+              console.log("Coordinator processing multiple assets");
+              const assets = extractJobAssets(job);
+              console.log(
+                `Found ${assets.length} assets for ${generation.placeholderIds.length} placeholders`,
+              );
+
+              if (assets.length === 0) {
+                onError(
+                  imageId,
+                  "Generation completed but no media was returned.",
+                );
+                return;
+              }
+
+              // Return the job and all assets so the parent can distribute them
+              onComplete(imageId, assets[0]?.url || "", {
+                job,
+                assets,
+                isCoordinator: true,
+                placeholderIds: generation.placeholderIds,
+              });
+              return;
+            } else {
+              // Single image or non-coordinator fallback
+              const asset = extractAssetUrl(job);
+              if (!asset?.url) {
+                onError(
+                  imageId,
+                  "Generation completed but no media was returned.",
+                );
+                return;
+              }
+
+              onComplete(imageId, asset.url, { job, asset });
+              return;
+            }
+          }
+
+          if (
+            ["failed", "cancelled", "system_failure"].includes(normalizedStatus)
+          ) {
+            onError(
+              imageId,
+              job.error || job.errorMessage || "Generation failed to complete.",
+            );
+            return;
+          }
+
+          scheduleNextPoll(3000, 0);
+        } catch (error: any) {
+          if (attempt < 5) {
             scheduleNextPoll(1500 * (attempt + 1), attempt + 1);
             return;
           }
-          onError(imageId, "Generation not found.");
-          return;
+
+          const message =
+            error instanceof Error
+              ? error.message || "Generation failed"
+              : "Generation failed";
+          onError(imageId, message);
         }
+      };
 
-        if (!response.ok) {
-          const errorBody = await response
-            .text()
-            .catch(() => "Failed to fetch generation status.");
-          throw new Error(errorBody || "Failed to fetch generation status.");
-        }
+      pollStatus();
 
-        const payload = await response.json();
-        const job = payload.job ?? payload;
+      return () => {
+        isCancelled = true;
+        clearPolling();
+      };
+    }, [generation.runId, imageId, onComplete, onError, onStatus]);
 
-        const rawStatus = (
-          job?.output?.status ||
-          job?.status ||
-          "unknown"
-        ).toString();
-        const normalizedStatus = rawStatus.toLowerCase();
+    return null;
+  },
+);
 
-        onStatus?.(imageId, rawStatus, job);
-
-        if (normalizedStatus === "completed") {
-          const asset = extractAssetUrl(job);
-          if (!asset?.url) {
-            onError(imageId, "Generation completed but no media was returned.");
-            return;
-          }
-
-          onComplete(imageId, asset.url, { job, asset });
-          return;
-        }
-
-        if (
-          ["failed", "cancelled", "system_failure"].includes(normalizedStatus)
-        ) {
-          onError(
-            imageId,
-            job.error || job.errorMessage || "Generation failed to complete.",
-          );
-          return;
-        }
-
-        scheduleNextPoll(2000, 0);
-      } catch (error: any) {
-        if (attempt < 5) {
-          scheduleNextPoll(1500 * (attempt + 1), attempt + 1);
-          return;
-        }
-
-        const message =
-          error instanceof Error
-            ? error.message || "Generation failed"
-            : "Generation failed";
-        onError(imageId, message);
-      }
-    };
-
-    pollStatus();
-
-    return () => {
-      isCancelled = true;
-      clearPolling();
-    };
-  }, [generation.runId, imageId, onComplete, onError, onStatus]);
-
-  return null;
-};
+StreamingImage.displayName = "StreamingImage";

--- a/src/hooks/useMultiImageGeneration.ts
+++ b/src/hooks/useMultiImageGeneration.ts
@@ -1,0 +1,198 @@
+import { useCallback, type Dispatch, type SetStateAction } from "react";
+import { createCanvasImagesFromAssets } from "@/utils/imageGeneration";
+import type { ActiveGeneration, PlacedImage } from "@/types/canvas";
+
+interface ViewportInfo {
+  x: number;
+  y: number;
+  scale: number;
+}
+
+interface CanvasSize {
+  width: number;
+  height: number;
+}
+
+interface MultiImageGenerationHandlers {
+  onStatus: (id: string, status: string, job?: any) => void;
+  onComplete: (id: string, finalUrl: string, payload?: any) => void;
+  onError: (id: string, error: string) => void;
+}
+
+interface UseMultiImageGenerationProps {
+  activeGenerations: Map<string, ActiveGeneration>;
+  setActiveGenerations: (
+    updater: (
+      prev: Map<string, ActiveGeneration>,
+    ) => Map<string, ActiveGeneration>,
+  ) => void;
+  setImages: Dispatch<SetStateAction<PlacedImage[]>>;
+  setSelectedIds: (ids: string[]) => void;
+  setIsGenerating: (generating: boolean) => void;
+  saveToStorage: () => void;
+  viewport: ViewportInfo;
+  canvasSize: CanvasSize;
+}
+
+export const useMultiImageGeneration = ({
+  activeGenerations,
+  setActiveGenerations,
+  setImages,
+  setSelectedIds,
+  setIsGenerating,
+  saveToStorage,
+  viewport,
+  canvasSize,
+}: UseMultiImageGenerationProps): MultiImageGenerationHandlers => {
+  const handleStatus = useCallback(
+    (id: string, status: string, job?: any) => {
+      setActiveGenerations((prev) => {
+        const existing = prev.get(id);
+        if (!existing) {
+          return prev;
+        }
+
+        const next = new Map(prev);
+        next.set(id, {
+          ...existing,
+          status,
+          jobId: job?.id,
+          runId: job?.runId ?? existing.runId,
+        });
+        return next;
+      });
+    },
+    [setActiveGenerations],
+  );
+
+  const handleComplete = useCallback(
+    (id: string, finalUrl: string, payload?: any) => {
+      console.log("Multi-image onComplete called:", {
+        id,
+        finalUrl,
+        isCoordinator: payload?.isCoordinator,
+      });
+
+      // If this is a coordinator with multiple assets, distribute them
+      if (
+        payload?.isCoordinator &&
+        payload?.assets &&
+        payload?.placeholderIds
+      ) {
+        console.log("Processing coordinator completion with multiple assets");
+
+        const { updatedPlaceholders, newImages } = createCanvasImagesFromAssets(
+          payload.assets,
+          payload.placeholderIds,
+          viewport,
+          canvasSize,
+        );
+
+        // Update all placeholders at once
+        setImages((prev) => {
+          const placeholderMap = new Map<string, PlacedImage>(
+            updatedPlaceholders.map((p) => [p.id, p as PlacedImage]),
+          );
+
+          const newPlacedImages: PlacedImage[] = newImages.map((img) => ({
+            ...img,
+          }));
+
+          return [
+            ...prev.map((img) => placeholderMap.get(img.id) || img),
+            ...newPlacedImages,
+          ];
+        });
+
+        // Clean up all placeholders from active generations
+        setActiveGenerations((prev) => {
+          const newMap = new Map(prev);
+          payload.placeholderIds.forEach((placeholderId: string) => {
+            newMap.delete(placeholderId);
+          });
+          if (newMap.size === 0) {
+            setIsGenerating(false);
+          }
+          return newMap;
+        });
+
+        // Select all generated images
+        const allGeneratedIds = [
+          ...updatedPlaceholders.map((p) => p.id),
+          ...newImages.map((img) => img.id),
+        ];
+        if (allGeneratedIds.length > 0) {
+          setSelectedIds(allGeneratedIds);
+        }
+      } else {
+        // Single image processing (fallback or non-coordinator)
+        setImages((prev) =>
+          prev.map((img) =>
+            img.id === id
+              ? {
+                  ...img,
+                  src: finalUrl,
+                  width:
+                    payload?.asset?.width && payload.asset.width > 0
+                      ? Math.min(payload.asset.width, 1024)
+                      : img.width,
+                  height:
+                    payload?.asset?.height && payload.asset.height > 0
+                      ? Math.min(payload.asset.height, 1024)
+                      : img.height,
+                }
+              : img,
+          ),
+        );
+
+        setActiveGenerations((prev) => {
+          const newMap = new Map(prev);
+          newMap.delete(id);
+          if (newMap.size === 0) {
+            setIsGenerating(false);
+          }
+          return newMap;
+        });
+      }
+
+      // Immediately save after generation completes
+      setTimeout(() => {
+        saveToStorage();
+      }, 100);
+    },
+    [
+      setImages,
+      setActiveGenerations,
+      setSelectedIds,
+      setIsGenerating,
+      saveToStorage,
+      viewport,
+      canvasSize,
+    ],
+  );
+
+  const handleError = useCallback(
+    (id: string, error: string) => {
+      console.error(`StreamingImage ${id} error:`, error);
+
+      // Remove from active generations
+      setActiveGenerations((prev) => {
+        const newMap = new Map(prev);
+        newMap.delete(id);
+        if (newMap.size === 0) {
+          setIsGenerating(false);
+        }
+        return newMap;
+      });
+
+      // Could also show toast error here if needed
+    },
+    [setActiveGenerations, setIsGenerating],
+  );
+
+  return {
+    onStatus: handleStatus,
+    onComplete: handleComplete,
+    onError: handleError,
+  };
+};

--- a/src/server/trpc/routers/_app.ts
+++ b/src/server/trpc/routers/_app.ts
@@ -802,7 +802,7 @@ export const appRouter = router({
         // Upload the segmented image to FAL storage
         console.log("Uploading segmented image to storage...");
         const uploadResult = await falClient.storage.upload(
-          new Blob([segmentedImage], { type: "image/png" }),
+          new Blob([new Uint8Array(segmentedImage)], { type: "image/png" }),
         );
 
         // Return the URL of the segmented object
@@ -858,6 +858,11 @@ export const appRouter = router({
             "portrait_16_9",
           ])
           .optional(),
+        parameters: z
+          .object({
+            num_images: z.number().optional(),
+          })
+          .optional(),
         apiKey: z.string().optional(),
       }),
     )
@@ -875,7 +880,10 @@ export const appRouter = router({
               image_size: input.imageSize || "square",
               num_inference_steps: 30,
               guidance_scale: 2.5,
-              num_images: 1,
+              num_images: Math.max(
+                1,
+                Math.min(4, Number(input.parameters?.num_images ?? 1)),
+              ),
               enable_safety_checker: true,
               output_format: "png",
               seed: input.seed,
@@ -912,6 +920,11 @@ export const appRouter = router({
         loraUrl: z.string().url().optional(),
         seed: z.number().optional(),
         lastEventId: z.string().optional(),
+        parameters: z
+          .object({
+            num_images: z.number().optional(),
+          })
+          .optional(),
         apiKey: z.string().optional(),
       }),
     )
@@ -931,7 +944,10 @@ export const appRouter = router({
             prompt: input.prompt,
             num_inference_steps: 30,
             guidance_scale: 2.5,
-            num_images: 1,
+            num_images: Math.max(
+              1,
+              Math.min(4, Number(input.parameters?.num_images ?? 1)),
+            ),
             enable_safety_checker: true,
             resolution_mode: "match_input",
             seed: input.seed,

--- a/src/types/canvas.ts
+++ b/src/types/canvas.ts
@@ -66,6 +66,8 @@ export interface ActiveGeneration {
   error?: string;
   sourceImageUrl?: string;
   realtimeToken?: string | null;
+  placeholderIds?: string[];
+  isCoordinator?: boolean;
 }
 
 export interface ActiveVideoGeneration {


### PR DESCRIPTION
- Extract multi-image generation logic to useMultiImageGeneration hook
- Add support for num_images parameter (1-4 images)
- Fix generation counter to show correct number (was showing +1)
- Update StreamingImage to handle coordinator pattern for multiple assets
- Make CanvasImage.isGenerated optional for type compatibility
- Add parameters.num_images to TRPC schemas