### PR TITLE
fix: preserve video generation when source image is deleted

### DIFF
--- a/src/types/canvas.ts
+++ b/src/types/canvas.ts
@@ -84,6 +84,10 @@ export interface ActiveVideoGeneration {
   cameraFixed?: boolean; // Whether to fix the camera position
   seed?: number; // Random seed to control video generation
   sourceImageId?: string; // ID of the image used for img2vid
+  sourceImageX?: number; // X position of source image
+  sourceImageY?: number; // Y position of source image
+  sourceImageWidth?: number; // Width of source image
+  sourceImageHeight?: number; // Height of source image
   sourceVideoId?: string; // ID of the video used for vid2vid
   isVideoToVideo?: boolean; // Indicates if this is a video-to-video transformation
   isVideoExtension?: boolean; // Indicates if this is a video extension


### PR DESCRIPTION
- Save source image position and dimensions when starting video generation
- Use saved info to place video even if source image no longer exists
- Update user feedback to indicate if source image was removed
- Prevents loss of video generation work when canvas is modified during generation